### PR TITLE
Remove reference to gif file

### DIFF
--- a/content/manifestos/2014-10-cybertwee.md
+++ b/content/manifestos/2014-10-cybertwee.md
@@ -14,7 +14,7 @@ our nectar is not just a lure
 or a trap for passing flies   
 but a self indulgent intrapersonal biofeedback mechanism spelled in emoji and gentle selfies.
 
-![the cybertwee manifesto](../content/manifestos-img/2014-cybertwee-manifesto.gif)
+![the cybertwee manifesto](../content/manifestos-img/2014-cybertwee-manifesto.png)
 
 ---
 


### PR DESCRIPTION
Latex/pandoc cannot include gif files.  Convert first frame to png and use that instead.
![2014-cybertwee-manifesto](https://cloud.githubusercontent.com/assets/2704175/16286950/5e34e40e-38a5-11e6-94c4-b9b2736c710c.png)
